### PR TITLE
Version 12.1.0 of gfortran

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -13,5 +13,6 @@ gfortran_version:
   - "9.3.0"
   - "10.2.1"
   - "11.0.1"
+  - "12.1.0"
 MACOSX_DEPLOYMENT_TARGET:
   - 10.9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ package:
   version: {{ version }}{{ version_suffix }}
 
 build:
-  number: 15
+  number: 16
   skip: True  # [win]
   skip: True  # [gfortran_version in ("11.0.1", "10.2.1") and cross_target_platform != "osx-arm64"]
   skip: True  # [gfortran_version not in ("11.0.1", "10.2.1") and (cross_target_platform == "osx-arm64" or target_platform == "osx-arm64")]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,11 @@
 {% set version_suffix = ".dev0" %}
 {% endif %}
 
+{% set version_suffix = "" %}
+{% if gfortran_version == "12.0.1" %}
+{% set version_suffix = ".dev0" %}
+{% endif %}
+
 package:
   name: gfortran-split
   version: {{ version }}{{ version_suffix }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
I added version 12.1.0 to the list of gfortran versions. I appended the .dev0 suffix as you did with 11.0.1 as I assume there are other checks required. Note that I did not modify the `skip` criteria, as at least I would like to have access to 12.1.0 on my x86 Mac. 

<!--
Please add any other relevant info below:
-->
This is my first time... so I don't know if I did this correctly. If there is something I can do to help please let me know, sorry for the trouble. 