### PR TITLE
BUG do not mix gfortran versions due to symlink

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -27,11 +27,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,9 +56,9 @@ outputs:
       skip: True  # [win]
     requirements:
       host:
-        - gfortran_{{ cross_target_platform }}
+        - gfortran_{{ cross_target_platform }} =={{ version }}
       run:
-        - gfortran_{{ cross_target_platform }}
+        - gfortran_{{ cross_target_platform }} =={{ version }}
         - ld64
         - cctools
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 outputs:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR fixes/helps an issue where a few odd things happen:

 - People would see two different versions of gfortran in their environments because the gfortran package did not a constraint on the `_impl` package version.
 - The symlink to the `gfortran` binary was reversed. By not mixing versions, we avoid most errors due to incompatible packages. There is still an issue with incompatible builds.

This PR needs a repodata patch to add the constraints here and fix up incompatible builds.