### PR TITLE
gfortran v15.1.0, v14.3.0 & v13.4.0; drop v12

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,28 +8,28 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_cross_target_platformosx-64gfortran_version12.4.0macos_machinex86_64-apple-darwin13.4.0:
-        CONFIG: linux_64_cross_target_platformosx-64gfortran_version12.4.0macos_machinex86_64-apple-darwin13.4.0
+      linux_64_cross_target_platformosx-64gfortran_version13.4.0macos_machinex86_64-apple-darwin13.4.0:
+        CONFIG: linux_64_cross_target_platformosx-64gfortran_version13.4.0macos_machinex86_64-apple-darwin13.4.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-64gfortran_version13.3.0macos_machinex86_64-apple-darwin13.4.0:
-        CONFIG: linux_64_cross_target_platformosx-64gfortran_version13.3.0macos_machinex86_64-apple-darwin13.4.0
+      linux_64_cross_target_platformosx-64gfortran_version14.3.0macos_machinex86_64-apple-darwin13.4.0:
+        CONFIG: linux_64_cross_target_platformosx-64gfortran_version14.3.0macos_machinex86_64-apple-darwin13.4.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-64gfortran_version14.2.0macos_machinex86_64-apple-darwin13.4.0:
-        CONFIG: linux_64_cross_target_platformosx-64gfortran_version14.2.0macos_machinex86_64-apple-darwin13.4.0
+      linux_64_cross_target_platformosx-64gfortran_version15.1.0macos_machinex86_64-apple-darwin13.4.0:
+        CONFIG: linux_64_cross_target_platformosx-64gfortran_version15.1.0macos_machinex86_64-apple-darwin13.4.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-arm64gfortran_version12.4.0macos_machinearm64-apple-darwin20.0.0:
-        CONFIG: linux_64_cross_target_platformosx-arm64gfortran_version12.4.0macos_machinearm64-apple-darwin20.0.0
+      linux_64_cross_target_platformosx-arm64gfortran_version13.4.0macos_machinearm64-apple-darwin20.0.0:
+        CONFIG: linux_64_cross_target_platformosx-arm64gfortran_version13.4.0macos_machinearm64-apple-darwin20.0.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-arm64gfortran_version13.3.0macos_machinearm64-apple-darwin20.0.0:
-        CONFIG: linux_64_cross_target_platformosx-arm64gfortran_version13.3.0macos_machinearm64-apple-darwin20.0.0
+      linux_64_cross_target_platformosx-arm64gfortran_version14.3.0macos_machinearm64-apple-darwin20.0.0:
+        CONFIG: linux_64_cross_target_platformosx-arm64gfortran_version14.3.0macos_machinearm64-apple-darwin20.0.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformosx-arm64gfortran_version14.2.0macos_machinearm64-apple-darwin20.0.0:
-        CONFIG: linux_64_cross_target_platformosx-arm64gfortran_version14.2.0macos_machinearm64-apple-darwin20.0.0
+      linux_64_cross_target_platformosx-arm64gfortran_version15.1.0macos_machinearm64-apple-darwin20.0.0:
+        CONFIG: linux_64_cross_target_platformosx-arm64gfortran_version15.1.0macos_machinearm64-apple-darwin20.0.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,41 +8,41 @@ jobs:
     vmImage: macOS-13
   strategy:
     matrix:
-      osx_64_cross_target_platformosx-64gfortran_version12.4.0macos_machinex86_64-apple-darwin13.4.0:
-        CONFIG: osx_64_cross_target_platformosx-64gfortran_version12.4.0macos_machinex86_64-apple-darwin13.4.0
+      osx_64_cross_target_platformosx-64gfortran_version13.4.0:
+        CONFIG: osx_64_cross_target_platformosx-64gfortran_version13.4.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-64gfortran_version13.3.0macos_machinex86_64-apple-darwin13.4.0:
-        CONFIG: osx_64_cross_target_platformosx-64gfortran_version13.3.0macos_machinex86_64-apple-darwin13.4.0
+      osx_64_cross_target_platformosx-64gfortran_version14.3.0:
+        CONFIG: osx_64_cross_target_platformosx-64gfortran_version14.3.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-64gfortran_version14.2.0macos_machinex86_64-apple-darwin13.4.0:
-        CONFIG: osx_64_cross_target_platformosx-64gfortran_version14.2.0macos_machinex86_64-apple-darwin13.4.0
+      osx_64_cross_target_platformosx-64gfortran_version15.1.0:
+        CONFIG: osx_64_cross_target_platformosx-64gfortran_version15.1.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-arm64gfortran_version12.4.0macos_machinearm64-apple-darwin20.0.0:
-        CONFIG: osx_64_cross_target_platformosx-arm64gfortran_version12.4.0macos_machinearm64-apple-darwin20.0.0
+      osx_64_cross_target_platformosx-arm64gfortran_version13.4.0:
+        CONFIG: osx_64_cross_target_platformosx-arm64gfortran_version13.4.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-arm64gfortran_version13.3.0macos_machinearm64-apple-darwin20.0.0:
-        CONFIG: osx_64_cross_target_platformosx-arm64gfortran_version13.3.0macos_machinearm64-apple-darwin20.0.0
+      osx_64_cross_target_platformosx-arm64gfortran_version14.3.0:
+        CONFIG: osx_64_cross_target_platformosx-arm64gfortran_version14.3.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-arm64gfortran_version14.2.0macos_machinearm64-apple-darwin20.0.0:
-        CONFIG: osx_64_cross_target_platformosx-arm64gfortran_version14.2.0macos_machinearm64-apple-darwin20.0.0
+      osx_64_cross_target_platformosx-arm64gfortran_version15.1.0:
+        CONFIG: osx_64_cross_target_platformosx-arm64gfortran_version15.1.0
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-64gfortran_version12.4.0macos_machinex86_64-apple-darwin13.4.0:
-        CONFIG: osx_arm64_cross_target_platformosx-64gfortran_version12.4.0macos_machinex86_64-apple-darwin13.4.0
+      osx_arm64_cross_target_platformosx-64gfortran_version13.4.0:
+        CONFIG: osx_arm64_cross_target_platformosx-64gfortran_version13.4.0
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-64gfortran_version13.3.0macos_machinex86_64-apple-darwin13.4.0:
-        CONFIG: osx_arm64_cross_target_platformosx-64gfortran_version13.3.0macos_machinex86_64-apple-darwin13.4.0
+      osx_arm64_cross_target_platformosx-64gfortran_version14.3.0:
+        CONFIG: osx_arm64_cross_target_platformosx-64gfortran_version14.3.0
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-64gfortran_version14.2.0macos_machinex86_64-apple-darwin13.4.0:
-        CONFIG: osx_arm64_cross_target_platformosx-64gfortran_version14.2.0macos_machinex86_64-apple-darwin13.4.0
+      osx_arm64_cross_target_platformosx-64gfortran_version15.1.0:
+        CONFIG: osx_arm64_cross_target_platformosx-64gfortran_version15.1.0
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-arm64gfortran_version12.4.0macos_machinearm64-apple-darwin20.0.0:
-        CONFIG: osx_arm64_cross_target_platformosx-arm64gfortran_version12.4.0macos_machinearm64-apple-darwin20.0.0
+      osx_arm64_cross_target_platformosx-arm64gfortran_version13.4.0:
+        CONFIG: osx_arm64_cross_target_platformosx-arm64gfortran_version13.4.0
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-arm64gfortran_version13.3.0macos_machinearm64-apple-darwin20.0.0:
-        CONFIG: osx_arm64_cross_target_platformosx-arm64gfortran_version13.3.0macos_machinearm64-apple-darwin20.0.0
+      osx_arm64_cross_target_platformosx-arm64gfortran_version14.3.0:
+        CONFIG: osx_arm64_cross_target_platformosx-arm64gfortran_version14.3.0
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-arm64gfortran_version14.2.0macos_machinearm64-apple-darwin20.0.0:
-        CONFIG: osx_arm64_cross_target_platformosx-arm64gfortran_version14.2.0macos_machinearm64-apple-darwin20.0.0
+      osx_arm64_cross_target_platformosx-arm64gfortran_version15.1.0:
+        CONFIG: osx_arm64_cross_target_platformosx-arm64gfortran_version15.1.0
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.ci_support/linux_64_cross_target_platformosx-64gfortran_version13.4.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-64gfortran_version13.4.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -7,13 +7,13 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 gfortran_version:
-- 12.4.0
+- 13.4.0
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cross_target_platformosx-64gfortran_version14.3.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-64gfortran_version14.3.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -1,19 +1,21 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+- '10.9'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 gfortran_version:
-- 13.3.0
+- 14.3.0
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 target_platform:
-- osx-arm64
+- linux-64
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/linux_64_cross_target_platformosx-64gfortran_version15.1.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-64gfortran_version15.1.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -11,7 +11,7 @@ cross_target_platform:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 gfortran_version:
-- 14.2.0
+- 15.1.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/linux_64_cross_target_platformosx-arm64gfortran_version13.4.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-arm64gfortran_version13.4.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -11,7 +11,7 @@ cross_target_platform:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 gfortran_version:
-- 14.2.0
+- 13.4.0
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.ci_support/linux_64_cross_target_platformosx-arm64gfortran_version14.3.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-arm64gfortran_version14.3.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -1,19 +1,21 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+- '10.9'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
-gfortran_version:
-- 12.4.0
-macos_machine:
-- x86_64-apple-darwin13.4.0
-target_platform:
 - osx-arm64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+gfortran_version:
+- 14.3.0
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- linux-64
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/linux_64_cross_target_platformosx-arm64gfortran_version15.1.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-arm64gfortran_version15.1.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -1,19 +1,21 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+- '10.9'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-arm64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 gfortran_version:
-- 12.4.0
+- 15.1.0
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:
-- osx-arm64
+- linux-64
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_cross_target_platformosx-64gfortran_version13.4.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-64gfortran_version13.4.0.yaml
@@ -1,21 +1,19 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- conda
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 gfortran_version:
-- 13.3.0
+- 13.4.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_cross_target_platformosx-64gfortran_version14.3.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-64gfortran_version14.3.0.yaml
@@ -1,21 +1,19 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- conda
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 gfortran_version:
-- 12.4.0
+- 14.3.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_cross_target_platformosx-64gfortran_version15.1.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-64gfortran_version15.1.0.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cross_target_platform:
 - osx-64
 gfortran_version:
-- 13.3.0
+- 15.1.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_64_cross_target_platformosx-arm64gfortran_version13.4.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-arm64gfortran_version13.4.0.yaml
@@ -1,19 +1,19 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.13'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
-gfortran_version:
-- 14.2.0
-macos_machine:
-- x86_64-apple-darwin13.4.0
-target_platform:
 - osx-arm64
+gfortran_version:
+- 13.4.0
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-64
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_cross_target_platformosx-arm64gfortran_version14.3.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-arm64gfortran_version14.3.0.yaml
@@ -1,19 +1,19 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.13'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
-gfortran_version:
-- 13.3.0
-macos_machine:
-- x86_64-apple-darwin13.4.0
-target_platform:
 - osx-arm64
+gfortran_version:
+- 14.3.0
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-64
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_64_cross_target_platformosx-arm64gfortran_version15.1.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-arm64gfortran_version15.1.0.yaml
@@ -7,11 +7,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 gfortran_version:
-- 12.4.0
+- 15.1.0
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_cross_target_platformosx-64gfortran_version13.4.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-64gfortran_version13.4.0.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -9,11 +9,11 @@ channel_targets:
 cross_target_platform:
 - osx-64
 gfortran_version:
-- 14.2.0
+- 13.4.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:
-- osx-64
+- osx-arm64
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_arm64_cross_target_platformosx-64gfortran_version14.3.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-64gfortran_version14.3.0.yaml
@@ -1,19 +1,19 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
-gfortran_version:
-- 14.2.0
-macos_machine:
-- arm64-apple-darwin20.0.0
-target_platform:
 - osx-64
+gfortran_version:
+- 14.3.0
+macos_machine:
+- x86_64-apple-darwin13.4.0
+target_platform:
+- osx-arm64
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_arm64_cross_target_platformosx-64gfortran_version15.1.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-64gfortran_version15.1.0.yaml
@@ -1,19 +1,19 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
-gfortran_version:
-- 13.3.0
-macos_machine:
-- arm64-apple-darwin20.0.0
-target_platform:
 - osx-64
+gfortran_version:
+- 15.1.0
+macos_machine:
+- x86_64-apple-darwin13.4.0
+target_platform:
+- osx-arm64
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_arm64_cross_target_platformosx-arm64gfortran_version13.4.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-arm64gfortran_version13.4.0.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cross_target_platform:
 - osx-arm64
 gfortran_version:
-- 14.2.0
+- 13.4.0
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.ci_support/osx_arm64_cross_target_platformosx-arm64gfortran_version14.3.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-arm64gfortran_version14.3.0.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -9,11 +9,11 @@ channel_targets:
 cross_target_platform:
 - osx-arm64
 gfortran_version:
-- 12.4.0
+- 14.3.0
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:
-- osx-64
+- osx-arm64
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.ci_support/osx_arm64_cross_target_platformosx-arm64gfortran_version15.1.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-arm64gfortran_version15.1.0.yaml
@@ -1,21 +1,19 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-cdt_name:
-- conda
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
 - osx-arm64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 gfortran_version:
-- 13.3.0
+- 15.1.0
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:
-- linux-64
+- osx-arm64
 zip_keys:
 - - cross_target_platform
   - macos_machine

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/README.md
+++ b/README.md
@@ -27,129 +27,129 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_cross_target_platformosx-64gfortran_version12.4.0macos_machinex86_64-apple-darwin13.4.0</td>
+              <td>linux_64_cross_target_platformosx-64gfortran_version13.4.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64gfortran_version12.4.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64gfortran_version13.4.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-64gfortran_version13.3.0macos_machinex86_64-apple-darwin13.4.0</td>
+              <td>linux_64_cross_target_platformosx-64gfortran_version14.3.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64gfortran_version13.3.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64gfortran_version14.3.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-64gfortran_version14.2.0macos_machinex86_64-apple-darwin13.4.0</td>
+              <td>linux_64_cross_target_platformosx-64gfortran_version15.1.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64gfortran_version14.2.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-64gfortran_version15.1.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64gfortran_version12.4.0macos_machinearm64-apple-darwin20.0.0</td>
+              <td>linux_64_cross_target_platformosx-arm64gfortran_version13.4.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64gfortran_version12.4.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64gfortran_version13.4.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64gfortran_version13.3.0macos_machinearm64-apple-darwin20.0.0</td>
+              <td>linux_64_cross_target_platformosx-arm64gfortran_version14.3.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64gfortran_version13.3.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64gfortran_version14.3.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64gfortran_version14.2.0macos_machinearm64-apple-darwin20.0.0</td>
+              <td>linux_64_cross_target_platformosx-arm64gfortran_version15.1.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64gfortran_version14.2.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformosx-arm64gfortran_version15.1.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64gfortran_version12.4.0macos_machinex86_64-apple-darwin13.4.0</td>
+              <td>osx_64_cross_target_platformosx-64gfortran_version13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64gfortran_version12.4.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64gfortran_version13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64gfortran_version13.3.0macos_machinex86_64-apple-darwin13.4.0</td>
+              <td>osx_64_cross_target_platformosx-64gfortran_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64gfortran_version13.3.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64gfortran_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64gfortran_version14.2.0macos_machinex86_64-apple-darwin13.4.0</td>
+              <td>osx_64_cross_target_platformosx-64gfortran_version15.1.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64gfortran_version14.2.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-64gfortran_version15.1.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64gfortran_version12.4.0macos_machinearm64-apple-darwin20.0.0</td>
+              <td>osx_64_cross_target_platformosx-arm64gfortran_version13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64gfortran_version12.4.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64gfortran_version13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64gfortran_version13.3.0macos_machinearm64-apple-darwin20.0.0</td>
+              <td>osx_64_cross_target_platformosx-arm64gfortran_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64gfortran_version13.3.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64gfortran_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64gfortran_version14.2.0macos_machinearm64-apple-darwin20.0.0</td>
+              <td>osx_64_cross_target_platformosx-arm64gfortran_version15.1.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64gfortran_version14.2.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_cross_target_platformosx-arm64gfortran_version15.1.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-64gfortran_version12.4.0macos_machinex86_64-apple-darwin13.4.0</td>
+              <td>osx_arm64_cross_target_platformosx-64gfortran_version13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64gfortran_version12.4.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64gfortran_version13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-64gfortran_version13.3.0macos_machinex86_64-apple-darwin13.4.0</td>
+              <td>osx_arm64_cross_target_platformosx-64gfortran_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64gfortran_version13.3.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64gfortran_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-64gfortran_version14.2.0macos_machinex86_64-apple-darwin13.4.0</td>
+              <td>osx_arm64_cross_target_platformosx-64gfortran_version15.1.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64gfortran_version14.2.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-64gfortran_version15.1.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64gfortran_version12.4.0macos_machinearm64-apple-darwin20.0.0</td>
+              <td>osx_arm64_cross_target_platformosx-arm64gfortran_version13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64gfortran_version12.4.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64gfortran_version13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64gfortran_version13.3.0macos_machinearm64-apple-darwin20.0.0</td>
+              <td>osx_arm64_cross_target_platformosx-arm64gfortran_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64gfortran_version13.3.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64gfortran_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64gfortran_version14.2.0macos_machinearm64-apple-darwin20.0.0</td>
+              <td>osx_arm64_cross_target_platformosx-arm64gfortran_version15.1.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6148&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64gfortran_version14.2.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_osx-64-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_cross_target_platformosx-arm64gfortran_version15.1.0" alt="variant">
                 </a>
               </td>
             </tr>
@@ -166,8 +166,8 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-gfortran-green.svg)](https://anaconda.org/conda-forge/gfortran) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gfortran.svg)](https://anaconda.org/conda-forge/gfortran) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gfortran.svg)](https://anaconda.org/conda-forge/gfortran) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gfortran.svg)](https://anaconda.org/conda-forge/gfortran) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-gfortran_osx--64-green.svg)](https://anaconda.org/conda-forge/gfortran_osx-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gfortran_osx-64.svg)](https://anaconda.org/conda-forge/gfortran_osx-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gfortran_osx-64.svg)](https://anaconda.org/conda-forge/gfortran_osx-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gfortran_osx-64.svg)](https://anaconda.org/conda-forge/gfortran_osx-64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-gfortran_osx--arm64-green.svg)](https://anaconda.org/conda-forge/gfortran_osx-arm64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gfortran_osx-arm64.svg)](https://anaconda.org/conda-forge/gfortran_osx-arm64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gfortran_osx-arm64.svg)](https://anaconda.org/conda-forge/gfortran_osx-arm64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gfortran_osx-arm64.svg)](https://anaconda.org/conda-forge/gfortran_osx-arm64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-gfortran__osx--64-green.svg)](https://anaconda.org/conda-forge/gfortran_osx-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gfortran_osx-64.svg)](https://anaconda.org/conda-forge/gfortran_osx-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gfortran_osx-64.svg)](https://anaconda.org/conda-forge/gfortran_osx-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gfortran_osx-64.svg)](https://anaconda.org/conda-forge/gfortran_osx-64) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-gfortran__osx--arm64-green.svg)](https://anaconda.org/conda-forge/gfortran_osx-arm64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/gfortran_osx-arm64.svg)](https://anaconda.org/conda-forge/gfortran_osx-arm64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gfortran_osx-arm64.svg)](https://anaconda.org/conda-forge/gfortran_osx-arm64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/gfortran_osx-arm64.svg)](https://anaconda.org/conda-forge/gfortran_osx-arm64) |
 
 Installing gfortran-split
 =========================

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,9 +5,9 @@ cross_target_platform:
   - osx-64
   - osx-arm64
 gfortran_version:
-  - 14.2.0
-  - 13.3.0
-  - 12.4.0
+  - 15.1.0
+  - 14.3.0
+  - 13.4.0
 zip_keys:
   - - cross_target_platform
     - macos_machine

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ outputs:
     build:
       run_exports:
         strong:
-          - libgfortran {{ libgfortran_major_version }}.*
+          - libgfortran
           - libgfortran{{ libgfortran_major_version }} >={{ version }}
       ignore_run_exports_from:
         - gfortran_{{ target_platform }}
@@ -37,7 +37,7 @@ outputs:
         - gfortran_impl_{{ target_platform }}
         - libgfortran-devel_{{ cross_target_platform }} =={{ version }}
         - libgfortran-devel_{{ target_platform }}         # [osx]
-        - libgfortran {{ libgfortran_major_version }}.*               # [target_platform == cross_target_platform]
+        - libgfortran                                                 # [target_platform == cross_target_platform]
         - libgfortran{{ libgfortran_major_version }} >={{ version }}  # [target_platform == cross_target_platform]
         - clang_{{ cross_target_platform }}
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% if gfortran_version is not defined %}
-{% set gfortran_version = "14.2.0" %}
+{% set gfortran_version = "15.1.0" %}
 {% endif %}
 {% set version = gfortran_version %}
 
@@ -10,7 +10,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win]
 
 outputs:


### PR DESCRIPTION
Waiting for https://github.com/conda-forge/gfortran_impl_osx-64-feedstock/pull/92